### PR TITLE
SCRUM-16 added user logout

### DIFF
--- a/auth/user_auth.py
+++ b/auth/user_auth.py
@@ -69,3 +69,19 @@ def user_info_with_token(access_token: str):
     else:
         print(f"Error: Error getting user info: {response}")
         return None
+
+def logout_with_token(access_token: str):
+    """
+    Logout the user by revoking the access token.
+
+    :param access_token: Access token to revoke.
+    :return: True if successful, otherwise False.
+    """
+
+    response = cognito_client.global_sign_out(AccessToken=access_token)
+
+    if response.get("ResponseMetadata").get("HTTPStatusCode") == 200:
+        return True
+    else:
+        print(f"Error: Error logging out: {response}")
+        return False

--- a/routers/user.py
+++ b/routers/user.py
@@ -8,7 +8,8 @@ from starlette.responses import JSONResponse
 
 from auth.auth import get_current_user, jwks
 from auth.JWTBearer import JWTAuthorizationCredentials, JWTBearer
-from auth.user_auth import auth_with_code, user_info_with_token
+from auth.user_auth import (auth_with_code, logout_with_token,
+                            user_info_with_token)
 from crud.userRepo import create_user, get_user_by_email, get_user_by_username
 from db.database import get_db
 from models.user import User
@@ -73,3 +74,18 @@ async def current_user(
         status_code=200,
         content=jsonable_encoder(get_user_by_username(username=username, db=db)),
     )
+
+@router.get("/auth/logout", dependencies=[Depends(auth)])
+async def logout(credentials: JWTAuthorizationCredentials = Depends(auth)):
+    """
+    Function that logs out a user.
+
+    :param credentials: JWTAuthorizationCredentials object.
+    :return: Message if logout is successful, otherwise raise an HTTPException.
+    """
+
+    result = logout_with_token(credentials.jwt_token)
+    if result:
+        return JSONResponse(status_code=200, content="Logout successful")
+    else:
+        raise HTTPException(status_code=401, detail="Error loging out...")

--- a/tests/services/test_auth_service.py
+++ b/tests/services/test_auth_service.py
@@ -5,7 +5,8 @@ from unittest.mock import patch
 
 import pytest
 
-from auth.user_auth import auth_with_code, user_info_with_token
+from auth.user_auth import (auth_with_code, logout_with_token,
+                            user_info_with_token)
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -90,7 +91,6 @@ def test_user_info_with_token(mock_cognito_client_get_user_function):
     assert result == {"ResponseMetadata": {"HTTPStatusCode": 200}}
 
 
-# 400 it's just a random error status code to test the error handling
 @patch(
     "auth.user_auth.cognito_client.get_user",
     return_value={"ResponseMetadata": {"HTTPStatusCode": 400}},
@@ -102,3 +102,28 @@ def test_unsuccessful_user_info_with_token(mock_cognito_client_get_user_function
         AccessToken="access_token_2"
     )
     assert result is None
+
+@patch(
+    "auth.user_auth.cognito_client.global_sign_out",
+    return_value={"ResponseMetadata": {"HTTPStatusCode": 200}},
+)
+def test_logout_with_token(mock_cognito_client_global_sign_out_function):
+    result = logout_with_token("access_token")
+
+    mock_cognito_client_global_sign_out_function.assert_called_once_with(
+        AccessToken="access_token"
+    )
+    assert result == True
+
+
+@patch(
+    "auth.user_auth.cognito_client.global_sign_out",
+    return_value={"ResponseMetadata": {"HTTPStatusCode": 400}},
+)
+def test_unsuccessful_logout_with_token(mock_cognito_client_global_sign_out_function):
+    result = logout_with_token("access_token_2")
+
+    mock_cognito_client_global_sign_out_function.assert_called_once_with(
+        AccessToken="access_token_2"
+    )
+    assert result == False


### PR DESCRIPTION
This pull request introduces a new logout functionality for users, including the implementation of the logout endpoint, the necessary backend logic, and corresponding tests. The most important changes include adding the `logout_with_token` function, integrating the logout endpoint into the router, and creating tests for the new functionality.

### New Functionality:

* [`auth/user_auth.py`](diffhunk://#diff-70ea7e1f19ad78e5daa1b70aab3f042f5a196a435d274fd68620a49fb4e1bc29R72-R87): Added `logout_with_token` function to handle user logout by revoking the access token.

### Router Integration:

* [`routers/user.py`](diffhunk://#diff-78dc28fba38afcfbb0579439e6751c1f5fc706e926b050eb58d21c69e6a2c048L11-R12): Imported `logout_with_token` and added a new `/auth/logout` endpoint to handle user logout requests. [[1]](diffhunk://#diff-78dc28fba38afcfbb0579439e6751c1f5fc706e926b050eb58d21c69e6a2c048L11-R12) [[2]](diffhunk://#diff-78dc28fba38afcfbb0579439e6751c1f5fc706e926b050eb58d21c69e6a2c048R77-R91)

### Testing:

* [`tests/routers/test_auth.py`](diffhunk://#diff-005c6eba8e74b5123d5fb3edadd525f472c745ee5f20cae7b73a13a5acb1a91bR130-R170): Added tests `test_successful_logout` and `test_unsuccessful_logout` to verify the behavior of the logout endpoint.
* [`tests/services/test_auth_service.py`](diffhunk://#diff-9668d6580f212cc12410ad078aaa955e0e181b775c0898f10df67e326058bf44R105-R129): Added tests `test_logout_with_token` and `test_unsuccessful_logout_with_token` to verify the `logout_with_token` function.

### Import Adjustments:

* [`tests/services/test_auth_service.py`](diffhunk://#diff-9668d6580f212cc12410ad078aaa955e0e181b775c0898f10df67e326058bf44L8-R9): Updated imports to include `logout_with_token`.