### PR TITLE
added get_tasks_by_status

### DIFF
--- a/crud/task.py
+++ b/crud/task.py
@@ -38,3 +38,7 @@ def get_task_by_id(task_id: str, db: Session = Depends(get_db)):
     if task is None:
         raise HTTPException(status_code=404, detail="Task not found")
     return task
+
+def get_task_by_status(status: str, db: Session = Depends(get_db)):
+    tasks = db.query(TaskModel).filter(TaskModel.status == status).all()
+    return tasks

--- a/routers/task.py
+++ b/routers/task.py
@@ -1,3 +1,4 @@
+import logging
 from typing import List
 
 from fastapi import APIRouter, Depends, HTTPException
@@ -5,7 +6,8 @@ from sqlalchemy.orm import Session
 
 from auth.auth import get_current_user, jwks
 from auth.JWTBearer import JWTBearer
-from crud.task import create_task, get_task_by_id, get_task_by_user_id
+from crud.task import (create_task, get_task_by_id, get_task_by_status,
+                       get_task_by_user_id)
 from crud.user import get_user_by_username
 from db.database import get_db
 from models.task import Task as TaskModel
@@ -36,3 +38,9 @@ async def get_tasks(user_username=Depends(get_current_user), db: Session = Depen
 @router.get("/tasks/{task_id}", response_model=TaskInDB, dependencies=[Depends(auth)])
 async def get_task(task_id: str, db: Session = Depends(get_db)):
     return get_task_by_id(task_id, db)
+
+# get tasks by status
+@router.get("/tasks/status/{status}", response_model=List[TaskInDB], dependencies=[Depends(auth)])
+async def get_tasks_by_status(status: str, db: Session = Depends(get_db)):
+    tasks = get_task_by_status(status, db)
+    return tasks

--- a/tests/crud/test_crud.py
+++ b/tests/crud/test_crud.py
@@ -9,7 +9,8 @@ from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session, sessionmaker
 from testcontainers.mysql import MySqlContainer
 
-from crud.task import create_task, get_task_by_id, get_task_by_user_id
+from crud.task import (create_task, get_task_by_id, get_task_by_status,
+                       get_task_by_user_id)
 from crud.user import create_user, get_user_by_email, get_user_by_username
 from db.database import get_db
 from main import app
@@ -160,3 +161,17 @@ def test_create_task_exception(test_db, test_user: UserModel):
 
     assert exc_info.value.status_code == 500
     assert exc_info.value.detail == "An error occurred while creating the task."
+
+def test_get_task_by_status(test_db, test_user: UserModel):
+    new_task = TaskCreate(
+        title="Test Task",
+        description="Test Description",
+        priority="low",
+        deadline=datetime.now(timezone.utc) + timedelta(days=3),
+    )
+
+    task = create_task(new_task, test_user.id, test_db)
+    tasks = get_task_by_status("todo", test_db)
+    assert tasks is not None
+    assert len(tasks) == 1
+    assert tasks[0] == task


### PR DESCRIPTION
This pull request introduces functionality to retrieve tasks by their status, along with corresponding updates to the router and test files. The most important changes include adding a new function to fetch tasks by status, updating the router to include a new endpoint, and adding tests for the new functionality.

### New Functionality:
* Added `get_task_by_status` function in `crud/task.py` to fetch tasks based on their status.

### Router Updates:
* Updated imports and added a new endpoint `/tasks/status/{status}` in `routers/task.py` to handle requests for tasks by status. [[1]](diffhunk://#diff-34a85b9525bb969b96c04301cd37cd66bb907856626d02f7b433ffee46539f86R1-R10) [[2]](diffhunk://#diff-34a85b9525bb969b96c04301cd37cd66bb907856626d02f7b433ffee46539f86R41-R46)

### Testing:
* Added a test case `test_get_task_by_status` in `tests/crud/test_crud.py` to verify the new functionality.
* Added a test case `test_get_tasks_by_status` in `tests/routers/test_task.py` to ensure the new endpoint returns the correct data.