### PR TITLE
SCRUM-25 added delete task to backend

### DIFF
--- a/crud/task.py
+++ b/crud/task.py
@@ -71,3 +71,18 @@ def update_task(task_id: str, task: TaskUpdate, db: Session = Depends(get_db)):
         raise HTTPException(status_code=500, detail="An error occurred while updating the task.") from e
     
     return db_task
+
+def delete_task(task_id: str, db: Session = Depends(get_db)):
+    db_task = db.query(TaskModel).filter(TaskModel.id == task_id).first()
+
+    if db_task is None:
+        raise HTTPException(status_code=404, detail="Task not found")
+
+    try:
+        db.delete(db_task)
+        db.commit()
+    except SQLAlchemyError as e:
+        db.rollback()
+        raise HTTPException(status_code=500, detail="An error occurred while deleting the task.") from e
+
+    return db_task

--- a/routers/task.py
+++ b/routers/task.py
@@ -6,8 +6,8 @@ from sqlalchemy.orm import Session
 
 from auth.auth import get_current_user, jwks
 from auth.JWTBearer import JWTBearer
-from crud.task import (create_task, get_task_by_id, get_task_by_status,
-                       get_task_by_user_id, update_task)
+from crud.task import (create_task, delete_task, get_task_by_id,
+                       get_task_by_status, get_task_by_user_id, update_task)
 from crud.user import get_user_by_username
 from db.database import get_db
 from models.task import Task as TaskModel
@@ -53,3 +53,10 @@ async def update_task_by_id(task_id: str, task: TaskUpdate, db: Session = Depend
     except Exception as exc:
         logging.exception("Unexpected error updating task: %s", exc)
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="An error occurred while updating the task.") from exc
+    
+@router.delete("/tasks/{task_id}", dependencies=[Depends(auth)], status_code=204)
+async def delete_task_by_id(task_id: str, db: Session = Depends(get_db)):
+    
+    delete_task(task_id, db)
+
+    return None

--- a/tests/crud/test_crud.py
+++ b/tests/crud/test_crud.py
@@ -9,8 +9,8 @@ from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session, sessionmaker
 from testcontainers.mysql import MySqlContainer
 
-from crud.task import (create_task, get_task_by_id, get_task_by_status,
-                       get_task_by_user_id, update_task)
+from crud.task import (create_task, delete_task, get_task_by_id,
+                       get_task_by_status, get_task_by_user_id, update_task)
 from crud.user import create_user, get_user_by_email, get_user_by_username
 from db.database import get_db
 from main import app
@@ -201,3 +201,15 @@ def test_update_task(test_db, test_user: UserModel):
     assert updated_task.user_id == test_user.id
     assert updated_task.status == TaskStatus.TODO
     assert updated_task.created_at is not None
+
+def test_delete_task(test_db, test_user: UserModel):
+    new_task = TaskCreate(
+        title="Test Task",
+        description="Test Description",
+        priority="low",
+        deadline=datetime.now(timezone.utc) + timedelta(days=3),
+    )
+
+    task = create_task(new_task, test_user.id, test_db)
+    delete_task(task.id, test_db)
+    assert test_db.query(TaskModel).filter(TaskModel.id == task.id).first() is None

--- a/tests/routers/test_task.py
+++ b/tests/routers/test_task.py
@@ -268,3 +268,15 @@ def test_update_task(mock_jwt_bearer, mock_update_task, mock_db):
     assert response.json()["user_id"] == "user_id"
     assert response.json()["id"] == "task_id"
     assert response.json()["created_at"] is not None
+
+@patch("routers.task.delete_task")
+@patch.object(JWTBearer, "__call__", return_value=credentials)
+def test_delete_task(mock_jwt_bearer, mock_delete_task, mock_db):
+    app.dependency_overrides[auth] = lambda: credentials
+    app.dependency_overrides[get_current_user] = lambda: "username1"
+
+    headers = {"Authorization": "Bearer token"}
+
+    response = client.delete("/tasks/task_id", headers=headers)
+
+    assert response.status_code == 204


### PR DESCRIPTION
This pull request introduces a new feature to delete tasks and includes updates to the CRUD operations, router, and tests to support this feature. The most important changes are summarized below:

### CRUD Operations:
* Added `delete_task` function to `crud/task.py` to handle task deletion from the database.

### Router:
* Updated imports in `routers/task.py` to include the new `delete_task` function.
* Added a new route `/tasks/{task_id}` with a DELETE method to handle task deletion requests.

### Tests:
* Updated imports in `tests/crud/test_crud.py` to include the new `delete_task` function.
* Added `test_delete_task` function to `tests/crud/test_crud.py` to verify task deletion functionality.
* Added `test_delete_task` function to `tests/routers/test_task.py` to test the DELETE endpoint for task deletion.